### PR TITLE
Don't create a cluster without any markers

### DIFF
--- a/addon/components/g-map/marker-clusterer.js
+++ b/addon/components/g-map/marker-clusterer.js
@@ -17,6 +17,11 @@ export default class MarkerClustererComponent extends MapComponent {
   }
 
   setup(options, events) {
+    // Nothing to do when there are no markers
+    if (this.markerComponents.length === 0) {
+      return;
+    }
+
     options.imagePath ??= 'assets/markerclustererplus/images/m';
 
     const markerClusterer = new MarkerClusterer(

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,4 @@
+.ember-google-map {
+  width: 500px;
+  height: 500px;
+}


### PR DESCRIPTION
- Skip creating a cluster when there are no markers. Another option is
  to have an update method, but there could be some timing issues
  because we have to wait for the markers first. Then we either diff
  the markers and use `add/removeMarkers`, or use a private attribute
  like so:

  `cluster.setOptions({ ...options, markers_: this.markerComponents });`

  It's hard to say what the better option is here. It depends on how
  people are using the cluster component. If there are no complaints,
  then this is a much simpler approach.

- Add a default style to the map to see the map during the tests.