### PR TITLE
Disable dotenv in CI

### DIFF
--- a/config/dotenv.js
+++ b/config/dotenv.js
@@ -5,7 +5,10 @@
 const path = require('path');
 
 module.exports = function (env) {
+  const isCI = Boolean(process.env.CI);
+
   return {
+    enabled: !isCI, // disable for CI
     clientAllowedKeys: ['GOOGLE_MAPS_API_KEY'],
     fastbootAllowedKeys: [],
     failOnMissingKey: false,


### PR DESCRIPTION
We use GitHub secrets when running in CI.