### PR TITLE
Fix the default path to the cluster icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ The best way to do this is to register a one-time event with `@onceOn`.
 </GMap>
 ```
 
+#### More cluster icons
+
+The MarkerClustererPlus library comes with a small collection of default cluster icons to choose from. They're all copied to `/assets/markerclustererplus/images/`.
+
+
 😇 Maintainers
 --------------------------------------------------------------------------------
 

--- a/addon/components/g-map/marker-clusterer.js
+++ b/addon/components/g-map/marker-clusterer.js
@@ -22,7 +22,7 @@ export default class MarkerClustererComponent extends MapComponent {
       return;
     }
 
-    options.imagePath ??= 'assets/markerclustererplus/images/m';
+    options.imagePath ??= '/assets/markerclustererplus/images/m';
 
     const markerClusterer = new MarkerClusterer(
       this.map,


### PR DESCRIPTION
Use an absolute path, instead of a relative one, when providing the path to the default cluster icons. We don't want to search for the icons relative to the current route!