### PR TITLE
Implement an update hook, i.e. reuse the existing cluster

### DIFF
--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,44 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { A } from '@ember/array';
+import { action } from '@ember/object';
+import {
+  randomCoordinateAround,
+  randomCoordinatesAround,
+} from 'dummy/utils/coordinates';
+
+export default class ApplicationController extends Controller {
+  @service
+  googleMapsApi;
+
+  lat = '51.507568';
+  lng = '0';
+
+  locations = A();
+
+  constructor() {
+    super(...arguments);
+
+    let { lat, lng } = this;
+    this.getLocations({ lat, lng }, 1000).then((locations) =>
+      this.locations.pushObjects(locations)
+    );
+  }
+
+  async getLocations(center, count) {
+    await this.googleMapsApi.google;
+
+    return randomCoordinatesAround(center, count);
+  }
+
+  @action
+  addRandomLocation() {
+    let { lat, lng } = this;
+    this.locations.pushObject(randomCoordinateAround({ lat, lng }));
+  }
+
+  @action
+  removeFirstLocation() {
+    this.locations.shiftObject();
+  }
+}

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -2,3 +2,18 @@
   width: 500px;
   height: 500px;
 }
+
+.gm-style-button {
+  background: rgb(255, 255, 255) none repeat scroll 0% 0%;
+  border: 0px none;
+  margin: 10px;
+  margin-bottom: 20px;
+  padding: 10px;
+  text-transform: none;
+  appearance: none;
+  cursor: pointer;
+  user-select: none;
+  border-radius: 2px;
+  box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px;
+  font-family: Roboto, Arial, sans-serif;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,25 @@
-{{page-title "Dummy"}}
+{{page-title "Ember Google MarkerClustererPlus"}}
 
-<h2 id="title">Welcome to Ember</h2>
+<GMap @lat="51.507568" @lng="0" as |map|>
+  <map.markerClusterer as |cluster|>
+    {{#each this.locations as |location|}}
+      <cluster.marker @lat={{location.lat}} @lng={{location.lng}} />
+    {{/each}}
+  </map.markerClusterer>
+
+  <map.control
+    @position="BOTTOM"
+    title="Add a random marker to the cluster"
+    aria-label="Add a random marker to the cluster">
+    <button type="button" class="gm-style-button" {{on "click" this.addRandomLocation}}>➕</button>
+  </map.control>
+
+  <map.control
+    @position="BOTTOM"
+    title="Remove a marker from the cluster"
+    aria-label="Remove a marker from the cluster">
+    <button type="button" class="gm-style-button" {{on "click" this.removeFirstLocation}}>➖</button>
+  </map.control>
+</GMap>
 
 {{outlet}}

--- a/tests/dummy/app/utils/coordinates.js
+++ b/tests/dummy/app/utils/coordinates.js
@@ -1,0 +1,28 @@
+export function randomCoordinateAround({ lat, lng }) {
+  const heading = randomInt(1, 360);
+  const distance = randomInt(50, 1000);
+  const point = window.google.maps.geometry.spherical.computeOffset(
+    new window.google.maps.LatLng(lat, lng),
+    distance,
+    heading
+  );
+
+  return {
+    lat: point.lat(),
+    lng: point.lng(),
+  };
+}
+
+export function randomCoordinatesAround(center, count = 1) {
+  const coords = [];
+
+  for (let n = 0; n < count; n++) {
+    coords.push(randomCoordinateAround(center));
+  }
+
+  return coords;
+}
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}

--- a/tests/integration/components/g-map/marker-clusterer-test.js
+++ b/tests/integration/components/g-map/marker-clusterer-test.js
@@ -4,35 +4,11 @@ import { setupMapTest } from 'ember-google-maps/test-support';
 import { click, waitFor as waitFor_, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { A } from '@ember/array';
-
-function randomInt(min, max) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}
+import { randomCoordinatesAround } from 'dummy/utils/coordinates';
 
 // Increase the default timeouts. Things can take a while sometimes.
 function waitFor(selector, options = {}) {
   return waitFor_(selector, { timeout: 5000, ...options });
-}
-
-function randomCoordinatesAround({ lat, lng }, count = 1) {
-  let coords = [];
-
-  for (let n = 0; n < count; n++) {
-    let heading = randomInt(1, 360),
-      distance = randomInt(50, 1000),
-      point = window.google.maps.geometry.spherical.computeOffset(
-        new window.google.maps.LatLng(lat, lng),
-        distance,
-        heading
-      );
-
-    coords.push({
-      lat: point.lat(),
-      lng: point.lng(),
-    });
-  }
-
-  return coords;
 }
 
 module('Integration | Component | g-map/marker-clusterer', function (hooks) {
@@ -147,7 +123,7 @@ module('Integration | Component | g-map/marker-clusterer', function (hooks) {
 
     this.set('trackedLocations', A(this.locations));
 
-    let assertNumberOfMarkersMatch = (cluster, message = null) => {
+    let assertNumberOfMarkersMatch = (cluster, message = undefined) => {
       assert.equal(
         cluster.getTotalMarkers(),
         this.trackedLocations.length,
@@ -166,22 +142,16 @@ module('Integration | Component | g-map/marker-clusterer', function (hooks) {
     `);
 
     let api = await this.waitForMap();
-    let clusterApi = api.components.markerClusters[0];
+    let cluster = api.components.markerClusters[0].mapComponent;
 
-    assertNumberOfMarkersMatch(clusterApi.mapComponent, 'rendered a cluster');
+    assertNumberOfMarkersMatch(cluster, 'rendered a cluster');
 
     this.trackedLocations.popObject();
     await this.waitForMap();
-    assertNumberOfMarkersMatch(
-      clusterApi.mapComponent,
-      'removed a marker from the cluster'
-    );
+    assertNumberOfMarkersMatch(cluster, 'removed a marker from the cluster');
 
     this.trackedLocations.pushObject(this.locations[0]);
     await this.waitForMap();
-    assertNumberOfMarkersMatch(
-      clusterApi.mapComponent,
-      'added a marker to the cluster'
-    );
+    assertNumberOfMarkersMatch(cluster, 'added a marker to the cluster');
   });
 });


### PR DESCRIPTION
- Add a basic demo to the dummy app
- Implement an update method that:
  1. updates the options
  2. removes markers that were removed
  3. adds markers that were added
  4. repaints the clusters
- Update the tests to rely on retaining access to the cluster component.
  This is essentially an additional test assertion that the update
  method is working as expected.

Fixes #8.