### PR TITLE
Add transpilation support for nullish assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ module.exports = {
   name: require('./package').name,
 
   options: {
+    babel: {
+      plugins: ['@babel/plugin-proposal-logical-assignment-operators'],
+    },
+
     'ember-google-maps': {
       customComponents: {
         markerClusterer: 'g-map/marker-clusterer',

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
     "@googlemaps/markerclustererplus": "^1.2.0",
     "@sandydoo/tracked-maps-and-sets": "^2.2.2",
     "broccoli-funnel": "^3.0.8",


### PR DESCRIPTION
We use logical nullish assignment `??=` in the addon which isn’t fully supported everywhere. This commit let’s babel know how and when to transpile it.